### PR TITLE
docs(fabric): redact leaked Azure AD App credentials in README example

### DIFF
--- a/fabric/README.env.md
+++ b/fabric/README.env.md
@@ -45,10 +45,10 @@ d365_fo:
 
 In `fabric/.env`:
 ```bash
-D365FO_BASE_URL=https://mcpfo1.operations.dynamics.com
-D365FO_CLIENT_ID=b22be235-70fd-4aeb-a589-d265afaed22c
-D365FO_CLIENT_SECRET=hK98Q~zfZwHhaCk~XD0GQCuUL3mS1lminJT20a6L
-D365FO_TENANT_ID=a47b59dc-3c90-49c8-84bc-0c9fcaa05616
+D365FO_BASE_URL=https://your-tenant.operations.dynamics.com
+D365FO_CLIENT_ID=<your-app-client-id>
+D365FO_CLIENT_SECRET=<your-app-client-secret>
+D365FO_TENANT_ID=<your-azure-tenant-id>
 ```
 
 ## Environment Variables Reference


### PR DESCRIPTION
## Summary

GitHub Secret Scanning flagged two Azure AD Application Secrets that were committed in this repo with real values:
- https://github.com/luthersystems/cross-department-claims-settlement/security/secret-scanning/1
- https://github.com/luthersystems/cross-department-claims-settlement/security/secret-scanning/2

The `connectorhub.yaml` example was already cleaned in a prior commit (now uses `${VAR}` substitution). The remaining live values are in `fabric/README.env.md` lines 49–50 — this PR replaces them with placeholders.

## Status of the credentials

Both leaked secrets have been **confirmed deleted from Entra ID** as of today — the keys are gone on the Azure side. So the security risk is resolved at the source. This PR is documentation hygiene + push-protection compliance.

## Test plan
- [ ] After merge, dismiss the 2 Secret Scanning alerts as `revoked` (will be handled separately via API).
- [ ] Confirm no Secret Scanning re-flag on the modified file.